### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, "**" ]
+  pull_request:
+    branches: [ "**" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies (dev + test)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,test]"
+
+      - name: Pre-commit (ruff format + lint + mypy)
+        run: |
+          pre-commit run --all-files
+
+      - name: Ruff (explicit lint gate)
+        run: |
+          ruff check .
+
+      - name: Mypy (explicit type gate)
+        run: |
+          mypy .
+
+      - name: Pytest
+        env:
+          # Ensure deterministic runs and avoid any accidental GPU attempts
+          PYTHONHASHSEED: "0"
+        run: |
+          pytest -q

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Entropy Trading Engine
 
+![CI](https://github.com/<YOUR_GH_USER_OR_ORG>/entropy-trading-engine/actions/workflows/ci.yml/badge.svg)
+
 Production-ready skeleton for an entropy-driven trading assistant extending Derek's "Brain" proof system.
 
 ## Quickstart


### PR DESCRIPTION
## Summary
- add GitHub Actions CI to run pre-commit, ruff, mypy, and pytest on Python 3.11
- show CI status badge in README

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c78422a4f48320a03f2ca90082b2ad