### PR TITLE
Add packaging metadata and quickstart assets

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,8 @@
-MIT License
-
-Copyright (c) 2025 Derek Alexander Espinoza
+MIT License – Open-Source (Personal / Academic)
+Copyright (c) 2025 Derek Wins
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
+of this software and associated documentation files (the “Software”), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
@@ -12,10 +11,15 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+COMMERCIAL LICENSE
+If you use EntropyLab in a for-profit entity or charge for access, you must buy a
+Commercial License 
+Contact: derekalexanderespinoza@gmail.com for site-wide or multi-seat deals.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# EntropyLab ⚡  
+Turn market chaos into backtests in 13 seconds.  
+`pip install entropylab` → [Get Pro](https://entropylab.co)
+
+<!-- (Keep your existing README content below this line) -->
+
 # Entropy Trading Engine
 
 ![CI](https://github.com/<YOUR_GH_USER_OR_ORG>/entropy-trading-engine/actions/workflows/ci.yml/badge.svg)
@@ -31,3 +37,7 @@ Config
 Edit config/settings.yaml or use ENV (prefix ENTROPY_) to override thresholds, DB URL, symbols.
 
 Disclaimer: Research software. Not investment advice.
+
+## Commercial Use
+See [LICENSE](LICENSE).  
+Pro upgrade removes watermark & adds live-broker plugins.

--- a/entropylab/__init__.py
+++ b/entropylab/__init__.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+def backtest(prices, risk_free=0.0):
+    rets = prices.pct_change().dropna()
+    sharpe = ((rets.mean() - risk_free/252) / rets.std()) * (252 ** 0.5) if rets.std() else 0.0
+    print(f"Sharpe (entropylab): {sharpe:.2f}")
+    return {"sharpe": float(sharpe)}

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -1,0 +1,91 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# EntropyLab Quickstart ⚡\n",
+    "Backtest SPY in under a minute. If `entropylab` is installed, we’ll use it; otherwise we’ll run a tiny fallback to demonstrate the flow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, subprocess, importlib\n",
+    "def pip_install(pkg):\n",
+    "    subprocess.check_call([sys.executable, '-m', 'pip', 'install', pkg])\n",
+    "\n",
+    "try:\n",
+    "    import yfinance as yf\n",
+    "except Exception:\n",
+    "    pip_install('yfinance>=0.2.40')\n",
+    "    import yfinance as yf\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from datetime import datetime\n",
+    "\n",
+    "start = '2020-01-01'\n",
+    "end = '2020-12-31'\n",
+    "spy = yf.download('SPY', start=start, end=end, auto_adjust=True)\n",
+    "prices = spy['Close'].dropna()\n",
+    "prices.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fallback_backtest(prices: pd.Series, risk_free=0.0):\n",
+    "    rets = prices.pct_change().dropna()\n",
+    "    if rets.std() == 0:\n",
+    "        sharpe = 0.0\n",
+    "    else:\n",
+    "        sharpe = ((rets.mean() - risk_free/252) / rets.std()) * np.sqrt(252)\n",
+    "    nav = (1 + rets).cumprod()\n",
+    "    print(f\"Sharpe (fallback): {sharpe:.2f}\")\n",
+    "    return {\n",
+    "        'sharpe': float(sharpe),\n",
+    "        'final_return': float(nav.iloc[-1] - 1)\n",
+    "    }\n",
+    "\n",
+    "try:\n",
+    "    entropylab = importlib.import_module('entropylab')\n",
+    "    if hasattr(entropylab, 'backtest'):\n",
+    "        result = entropylab.backtest(prices)  # expected to print/return Sharpe\n",
+    "        print('Sharpe (entropylab):', getattr(result, 'sharpe', result))\n",
+    "    else:\n",
+    "        result = fallback_backtest(prices)\n",
+    "except Exception as e:\n",
+    "    print('[Info] entropylab not found or backtest() missing, using fallback.')\n",
+    "    result = fallback_backtest(prices)\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 🚀 Want to plug this into Interactive Brokers automatically?  \n",
+    "**Upgrade to EntropyLab Pro ($299 one-time)**"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='entropylab',
+    version='1.0.0',
+    author='Derek Alexander Espinoza ',
+    author_email='derekalexanderespinoza@gmail.com',
+    description='Entropy-powered backtesting engine',
+    long_description=open('README.md', encoding='utf-8').read(),
+    long_description_content_type='text/markdown',
+    url='https://github.com/derekwins88/entropylab',
+    packages=find_packages(exclude=("tests", "docs", "examples")),
+    install_requires=['pandas', 'numpy', 'matplotlib'],
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+    ],
+    python_requires='>=3.8',
+)


### PR DESCRIPTION
## Summary
- replace the root license with the provided dual license copy and update the README hero plus commercial notice
- add setuptools-based packaging metadata and a minimal entropylab backtest stub for the quickstart flow
- include the new examples/quickstart notebook showcasing SPY downloads and backtest fallback logic

## Testing
- `python -m pip install --upgrade pip build twine`
- `python -m build` *(fails: pyproject metadata conflicts with setup.py configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68df1e09e7f88320a90428e7b54a2842