### PR TITLE
Update licensing to IMM Cathedral Public License v1.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,25 +1,19 @@
-MIT License – Open-Source (Personal / Academic)
+IMM Cathedral Public License v1.0 (IMM-PL-1.0)
+
 Copyright (c) 2025 Derek Wins
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the “Software”), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted to any individual or organization ("user ") to view, study, and experiment with the IMM Cathedral software and its components ("Software") for personal, academic, or non-commercial research purposes.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Use of the Software for commercial, industrial, or institutional deployment—including integration into proprietary software, machine learning models, or enterprise-scale inference systems—is **strictly prohibited** without prior written consent from the author(s).
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Redistribution of modified or original copies of this Software is not permitted without express written permission.
 
-COMMERCIAL LICENSE
-If you use EntropyLab in a for-profit entity or charge for access, you must buy a
-Commercial License 
-Contact: derekalexanderespinoza@gmail.com for site-wide or multi-seat deals.
+The Software is provided "as is," without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and noninfringement.
+
+Use of this Software in validation pipelines, cryptographic verification chains, or policy coherence engines must include clear attribution to the original author(s) and a reference to the IMM Cathedral project repository.
+
+Commercial licensing is available. Please contact: derekalexanderespinoza88@gmail.com
+
+By using this Software, the User agrees to these terms.
+
+SPDX-License-Identifier: IMM-PL-1.0

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,10 @@ setup(
     url='https://github.com/derekwins88/entropylab',
     packages=find_packages(exclude=("tests", "docs", "examples")),
     install_requires=['pandas', 'numpy', 'matplotlib'],
+    license='IMM-PL-1.0',
     classifiers=[
         'Programming Language :: Python :: 3',
-        'License :: OSI Approved :: MIT License',
+        'License :: Other/Proprietary License',
         'Operating System :: OS Independent',
     ],
     python_requires='>=3.8',


### PR DESCRIPTION
## Summary
- replace the MIT license text with the IMM Cathedral Public License v1.0
- adjust package metadata to reference the new license and appropriate classifier

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f8524b5c08320a0271e3a8cf14626)